### PR TITLE
Add FeatureEnabled expression, schema metadata, and publish under @flippercloud scope

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,21 @@
+# Flipper Expressions
+
+JSON Schema (`schemas/*.json`) and JS library for Flipper Expressions. The schemas are the canonical spec; the Ruby gem reimplements the expressions and vendors these schemas + examples for its tests.
+
+## Keep flipper in sync when schemas or examples change
+
+Any time `schemas/*.json` or `examples/*.json` change here, the vendored copies in the [flippercloud/flipper](https://github.com/flippercloud/flipper) gem must be re-synced and its specs re-run — otherwise Ruby and JS drift apart.
+
+In a flipper checkout:
+
+```sh
+# Copies schemas/*.json and examples/*.json from this repo into flipper
+# (lib/flipper/expression/schemas + spec/fixtures/expressions/examples).
+# Defaults to a sibling ../expressions checkout; override with SOURCE.
+rake expressions:vendor SOURCE=/path/to/expressions
+
+# Then run flipper's specs to confirm Ruby agrees with the schema/examples.
+bundle exec rspec spec/flipper/expression/schema_spec.rb
+```
+
+See the README's "Adding a new expression" section for the full cross-repo workflow.

--- a/examples/FeatureEnabled.json
+++ b/examples/FeatureEnabled.json
@@ -1,0 +1,15 @@
+{
+  "valid": [
+    {
+      "expression": { "FeatureEnabled": ["other_feature"] }
+    },
+    {
+      "expression": { "FeatureEnabled": [{ "Property": ["feature_name"] }] }
+    }
+  ],
+  "invalid": [
+    { "FeatureEnabled": [] },
+    { "FeatureEnabled": ["a", "b"] },
+    { "FeatureEnabled": ["a"], "Any": [] }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flippercloud.io/expressions",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Library and Schema for evaluating Flipper Expressions",
   "type": "module",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@flippercloud.io/expressions",
+  "name": "@flippercloud/expressions",
   "version": "1.1.0",
   "description": "Library and Schema for evaluating Flipper Expressions",
   "type": "module",
@@ -16,7 +16,7 @@
       "require": "./dist/expressions.umd.cjs"
     }
   },
-  "repository": "https:://github.com/jnunemaker/flipper",
+  "repository": "https://github.com/flippercloud/expressions",
   "license": "MIT",
   "dependencies": {
     "ajv": "^8.12.0",

--- a/schemas/FeatureEnabled.schema.json
+++ b/schemas/FeatureEnabled.schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://www.flippercloud.io/expressions/FeatureEnabled.schema.json",
+  "title": "FeatureEnabled",
+  "description": "Returns true if the named feature is enabled for the current actor.",
+  "category": "Value",
+  "type": "array",
+  "items": { "$ref": "schema.json#/definitions/string" },
+  "minItems": 1,
+  "maxItems": 1
+}

--- a/schemas/PercentageOfActors.schema.json
+++ b/schemas/PercentageOfActors.schema.json
@@ -2,7 +2,8 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://www.flippercloud.io/expressions/PercentageOfActors.schema.json",
   "title": "PercentageOfActors",
-  "description": "",
+  "description": "Returns true when the actor falls within the given percentage for the feature.",
+  "category": "Condition",
   "type": "array",
   "items": [
     { "$ref": "schema.json#/definitions/string" },

--- a/schemas/Property.schema.json
+++ b/schemas/Property.schema.json
@@ -3,6 +3,7 @@
   "$id": "https://www.flippercloud.io/expressions/Property.schema.json",
   "title": "Property",
   "description": "Extract a property from context[properties].",
+  "category": "Value",
   "type": "array",
   "items": { "$ref": "schema.json#/definitions/string" },
   "minItems": 1,

--- a/schemas/Random.schema.json
+++ b/schemas/Random.schema.json
@@ -3,6 +3,7 @@
   "$id": "https://www.flippercloud.io/expressions/Random.schema.json",
   "title": "Random",
   "description": "Return a random number",
+  "category": "Value",
   "type": "array",
   "items": {
     "title": "Maximum",

--- a/schemas/Time.schema.json
+++ b/schemas/Time.schema.json
@@ -3,6 +3,7 @@
   "$id": "https://www.flippercloud.io/expressions/Time.schema.json",
   "title": "Time",
   "description": "A time in ISO8601 format",
+  "category": "Value",
   "type": "array",
   "items": {
     "title": "Time",

--- a/schemas/schema.json
+++ b/schemas/schema.json
@@ -65,11 +65,6 @@
       },
       "additionalProperties": false
     },
-    "property": {
-      "title": "Property Value",
-      "description": "A value stored in context[properties]: a string, number, boolean, or null.",
-      "$ref": "#/definitions/constant"
-    },
     "string": {
       "title": "String",
       "description": "A constant string value or a function that returns a string",

--- a/schemas/schema.json
+++ b/schemas/schema.json
@@ -44,6 +44,7 @@
         "Divide": { "$ref": "Divide.schema.json" },
         "Duration": { "$ref": "Duration.schema.json" },
         "Equal": { "$ref": "Equal.schema.json" },
+        "FeatureEnabled": { "$ref": "FeatureEnabled.schema.json" },
         "GreaterThan": { "$ref": "GreaterThan.schema.json" },
         "GreaterThanOrEqualTo": { "$ref": "GreaterThanOrEqualTo.schema.json" },
         "LessThan": { "$ref": "LessThan.schema.json" },
@@ -63,6 +64,11 @@
         "Time": { "$ref": "Time.schema.json" }
       },
       "additionalProperties": false
+    },
+    "property": {
+      "title": "Property Value",
+      "description": "A value stored in context[properties]: a string, number, boolean, or null.",
+      "$ref": "#/definitions/constant"
     },
     "string": {
       "title": "String",

--- a/vite.config.js
+++ b/vite.config.js
@@ -7,7 +7,7 @@ export default defineConfig({
     sourcemap: true,
     lib: {
       entry: resolve(__dirname, 'lib/index.js'),
-      name: '@flippercloud.io/expressions'
+      name: '@flippercloud/expressions'
     },
     rollupOptions: {
       external: [


### PR DESCRIPTION
## Summary
- **New expression:** Adds `FeatureEnabled`, which returns true when the named feature is enabled for the current actor. Includes the schema (`schemas/FeatureEnabled.schema.json`), valid/invalid examples (`examples/FeatureEnabled.json`), and registration in `schemas/schema.json`.
- **Schema metadata:** Adds `category` (Condition/Value) to several schemas and a description to `PercentageOfActors`.
- **npm scope:** Renames the package from `@flippercloud.io/expressions` (a personal user scope) to `@flippercloud/expressions` (the org we control, alongside `@flippercloud/flipper`). Fixes the broken `repository` URL. Schema `$id` URLs keep `www.flippercloud.io` — those are canonical schema identifiers tied to the website domain and the Ruby gem's `BaseURI`, not the npm scope.
- **Version + docs:** Bumps to 1.1.0 and adds `CLAUDE.md` documenting that schema/example changes must be re-synced into the flipper gem via `rake expressions:vendor`.

## Test plan
- [x] All vitest tests pass (286 tests, including the 263 schema/example validation tests that exercise the new `FeatureEnabled` examples)
- [x] `standard` lint clean
- [x] `npm run build` succeeds; `npm publish --dry-run` resolves to `@flippercloud/expressions@1.1.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)