### PR TITLE
Add publishConfig.access=public

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
   },
   "repository": "https://github.com/flippercloud/expressions",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "dependencies": {
     "ajv": "^8.12.0",
     "ajv-formats": "^2.1.1",


### PR DESCRIPTION
## What

Adds `publishConfig: { access: "public" }` to `package.json`.

## Why

`@flippercloud/expressions` is a scoped package, and npm defaults scoped packages to **restricted** access on publish. That means every publish requires the `--access public` flag, and forgetting it produces a confusing 402/403 error. Setting `publishConfig.access` to `public` bakes the right default into the package so `npm publish` just works — no flag needed.

## Test plan

- `npm publish` (or `npm publish --dry-run`) no longer needs `--access public`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)